### PR TITLE
Fix stack overflowing

### DIFF
--- a/src/WaveFunctionCollapse.elm
+++ b/src/WaveFunctionCollapse.elm
@@ -132,7 +132,11 @@ solve : TilesDefinition tileT socketT -> Grid tileT
 solve tilesDefinition =
     let
         (Model { propGrid }) =
-            solve_ <| propagate <| init tilesDefinition
+            let
+                nextModel =
+                    propagate <| init tilesDefinition
+            in
+            solve_ (done <| nextModel) nextModel
 
         convert propagationTile =
             case propagationTile of
@@ -145,13 +149,13 @@ solve tilesDefinition =
     Grid.map convert propGrid
 
 
-solve_ : Model tileT socketT -> Model tileT socketT
-solve_ model =
-    if done model then
+solve_ : Bool -> Model tileT socketT -> Model tileT socketT
+solve_ isDone model =
+    if isDone then
         model
 
     else
-        solve_ <| propagate model
+        solve_ (done model) (propagate model)
 
 
 {-| Execute a single step. This can mean picking the next random tile


### PR DESCRIPTION
Hi! Thanks for putting this out there! 

I have a 3x3 model stack overflowing, and this change seems to resolve it crashing (though it instead loops forever). A hanging page is a lot scarier than an elm crash though! My own tile definions must be imperfect, but I prefer a hang to a hard crash.

I don't now anything about the topic, https://functional-programming-in-elm.netlify.app/recursion/tail-call-elimination.html but this helped.